### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 {{ ansible_managed | comment }}
+{{ "system_role:journald" | comment(prefix="", postfix="") }}
 [Journal]
 {# Persistent journal #}
 {% if journald_persistent | bool %}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:journald
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.
