### PR TITLE
docs: use None for Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This role provides an easy way to configure systemd-journald logging service.
 
 ## Requirements
 
-This role uses only Ansible built-in modules.
+None
 
 ## Role Variables
 


### PR DESCRIPTION
If there are no Requirements, just say None - this is for
consistency with other system roles.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
