### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ __journald_required_facts:
   - distribution
   - distribution_major_version
   - distribution_version
+  - machine_id
   - os_family
 # the subsets of ansible_facts that need to be gathered in case any of the
 # facts in required_facts is missing; see the documentation of


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
