### PR TITLE
ci: tox-lsr version 3.1.1

### DIFF
--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create and push empty commit
+      - name: Create or rebase commit, add dump_packages callback
         run: |
           set -euxo pipefail
 


### PR DESCRIPTION
This is primarily for the update to ansible-plugin-scan to
work with the upcoming ostree changes, but also includes
some minor fixes which affect ci.
3.1.0 was released but not used due to a bug fixed in 3.1.1
See full release notes for 3.1.0 and 3.1.1
https://github.com/linux-system-roles/tox-lsr/releases

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
