### PR TITLE
feat: Adding syslog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Defaults to `true`.
 time span after which journald synchronizes currently used journal file to disk.
 By default role doesn't alter currently used value.
 
+- `journald_forward_to_syslog` - boolean variable, control whether log messages
+received by the journal daemon shall be forwarded to a traditional syslog daemon.
+Defaults to `false`.
+
 ## Example Playbook
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ journald_max_file_size: 0
 journald_per_user: false
 journald_compression: true
 journald_sync_interval: 0
+journald_forward_to_syslog: false

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -29,6 +29,7 @@ RutimeMaxFiles={{ journald_max_files }}
 RuntimeMaxFileSize={{ journald_max_file_size }}M
 {% endif %}
 Compress={{ journald_compression | bool | ternary("yes", "no") }}
+ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}
 {# SyncInterval= #}
 {% if journald_sync_interval | int != 0 %}
 SyncIntervalSec={{ journald_sync_interval }}m


### PR DESCRIPTION
Enhancement:
Adding support for ForwardToSyslog flag. 

Reason:
When using remote loging systems like splunk , logs should be in /var/log files.

Result:
Adding option to configure ForwardToSyslog flag.
 
Issue Tracker Tickets (Jira or BZ if any):
