### PR TITLE
fix: ForwardToSyslog only set for volatile

### DIFF
--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -29,9 +29,9 @@ RutimeMaxFiles={{ journald_max_files }}
 RuntimeMaxFileSize={{ journald_max_file_size }}M
 {% endif %}
 Compress={{ journald_compression | bool | ternary("yes", "no") }}
-ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}
 {# SyncInterval= #}
 {% if journald_sync_interval | int != 0 %}
 SyncIntervalSec={{ journald_sync_interval }}m
 {% endif %}
 {% endif %}
+ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}


### PR DESCRIPTION
Enhancement:
Allowing for syslog regardless of storage option.

Reason:
Allowing for syslog regardless of storage option.

Result:

Issue Tracker Tickets (Jira or BZ if any):
