### PR TITLE
fix: Compress applies to all storage modes, SyncInterval only to persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ unless otherwise indicated.
 
 - `journald_sync_interval` - integer variable, in minutes, configures the time
   span after which journald synchronizes the currently used journal file to
-  disk. By default role doesn't alter currently used value.
+  disk. By default role doesn't alter currently used value.  This setting is
+  only applicable for `journald_persistent: true`.  You will get a warning if
+  set otherwise.
 
 - `journald_forward_to_syslog` - boolean variable, control whether log messages
   received by the journal daemon shall be forwarded to a traditional syslog

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![ansible-lint.yml](https://github.com/linux-system-roles/journald/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/journald/actions/workflows/ansible-lint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/journald/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/journald/actions/workflows/ansible-test.yml) [![markdownlint.yml](https://github.com/linux-system-roles/journald/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/journald/actions/workflows/markdownlint.yml) [![woke.yml](https://github.com/linux-system-roles/journald/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/journald/actions/workflows/woke.yml)
 
-This role provides an easy way to configure systemd-journald logging service.
+This role provides an easy way to configure the systemd-journald logging
+service.
 
 ## Requirements
 
@@ -20,41 +21,46 @@ ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 
 ## Role Variables
 
-Role allows system administrator to configure basic systemd-journald settings,
-through following set of variables which form role's public API.
+The role allows system administrator to configure basic systemd-journald
+settings, through the following set of variables which form the role's public
+API.
 
 - `journald_persistent` - boolean variable which governs where journald stores
-log file. When set to `true` the logs will be stored on disk in
-`/var/log/journal/`. Defaults to `false`, i.e. `volatile` journal storage.
+  log file. When set to `true` the logs will be stored on disk in
+  `/var/log/journal/`. Defaults to `false`, i.e. `volatile` journal storage.
+
+**NOTE**: The following settings apply to both `persistent` and `volatile` modes
+unless otherwise indicated.
 
 - `journald_max_disk_size` - integer variable, in megabytes, that governs how
-much disk space can journal files occupy before some of them are deleted.
-No implicit value is configured by the role, hence default sizing calculation
-described in `man 5 journald.conf` applies.
+  much disk space can journal files occupy before some of them are deleted. No
+  implicit value is configured by the role, hence default sizing calculation
+  described in `man 5 journald.conf` applies.
 
 - `journald_max_files` - integer variable that governs how many journal files
-can be kept at maximum while respecting max disk size settings for journal.
-No implicit value is configured by default.
+  can be kept at maximum while respecting max disk size settings for journal. No
+  implicit value is configured by default.
 
-- `journald_max_file_size` - integer variable, in megabytes, describes maximum
-size of single journal file. No implicit configuration is set up by the role.
+- `journald_max_file_size` - integer variable, in megabytes, describes the
+ maximum size of single journal file. No implicit configuration is set up by the
+ role.
 
 - `journald_per_user` - boolean variable, allows to configure whether journald
-should keep log data separate for each user, e.g. allowing unprivileged users
-to read system log from their own user services. Defaults to `true`. Note that
-per user journal files are available only when `journald_persistent: true`.
+  should keep log data separate for each user, e.g. allowing unprivileged users
+  to read system log from their own user services. Defaults to `true`. Note that
+  per user journal files are available only when `journald_persistent: true`.
 
 - `journald_compression` - boolean variable instructs journald to apply
-compression to journald data objects that are bigger then default 512 bytes.
-Defaults to `true`.
+  compression to journald data objects that are bigger than default 512 bytes.
+  Defaults to `true`.
 
-- `journald_sync_interval` - integer variable, in minutes, configures the
-time span after which journald synchronizes currently used journal file to disk.
-By default role doesn't alter currently used value.
+- `journald_sync_interval` - integer variable, in minutes, configures the time
+  span after which journald synchronizes the currently used journal file to
+  disk. By default role doesn't alter currently used value.
 
 - `journald_forward_to_syslog` - boolean variable, control whether log messages
-received by the journal daemon shall be forwarded to a traditional syslog daemon.
-Defaults to `false`.
+  received by the journal daemon shall be forwarded to a traditional syslog
+  daemon. Defaults to `false`.
 
 ## Example Playbook
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,15 @@
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml
 
+- name: Warn if journald_sync_interval is set in volatile mode
+  debug:
+    msg: >-
+      WARNING - journald_sync_interval should not be set when
+      journald_persistent: false
+  when:
+    - journald_sync_interval | int != 0
+    - not journald_persistent
+
 - name: Ensure required packages are installed
   package:
     name: "{{ __journald_packages }}"

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -6,32 +6,33 @@
 {# Persistent journal #}
 {% if journald_persistent | bool %}
 Storage=persistent
-{% if journald_max_disk_size | int != 0 %}
+{%   if journald_max_disk_size | int != 0 %}
 SystemMaxUse={{ journald_max_disk_size }}M
-{% endif %}
-{% if journald_max_files | int != 0 %}
+{%   endif %}
+{%   if journald_max_files | int != 0 %}
 SystemMaxFiles={{ journald_max_files }}
-{% endif %}    
-{% if journald_max_file_size | int != 0 %}
+{%   endif %}
+{%   if journald_max_file_size | int != 0 %}
 SystemMaxFileSize={{ journald_max_file_size }}M
-{% endif %}
+{%   endif %}
 SplitMode={{ journald_per_user | bool | ternary("uid", "none") }}
 {# Volatile journal #}
 {% else %}
 Storage=volatile
-{% if journald_max_disk_size | int != 0 %}
+{%   if journald_max_disk_size | int != 0 %}
 RuntimeMaxUse={{ journald_max_disk_size }}M
-{% endif %}
-{% if journald_max_files | int != 0 %}
-RutimeMaxFiles={{ journald_max_files }}
-{% endif %}
-{% if journald_max_file_size | int != 0 %}
+{%   endif %}
+{%   if journald_max_files | int != 0 %}
+RuntimeMaxFiles={{ journald_max_files }}
+{%   endif %}
+{%   if journald_max_file_size | int != 0 %}
 RuntimeMaxFileSize={{ journald_max_file_size }}M
+{%   endif %}
 {% endif %}
-Compress={{ journald_compression | bool | ternary("yes", "no") }}
-{# SyncInterval= #}
+{# end of storage specific settings #}
+{# settings below here apply to all storage types #}
 {% if journald_sync_interval | int != 0 %}
 SyncIntervalSec={{ journald_sync_interval }}m
 {% endif %}
-{% endif %}
+Compress={{ journald_compression | bool | ternary("yes", "no") }}
 ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -16,6 +16,9 @@ SystemMaxFiles={{ journald_max_files }}
 SystemMaxFileSize={{ journald_max_file_size }}M
 {%   endif %}
 SplitMode={{ journald_per_user | bool | ternary("uid", "none") }}
+{% if journald_sync_interval | int != 0 %}
+SyncIntervalSec={{ journald_sync_interval }}m
+{% endif %}
 {# Volatile journal #}
 {% else %}
 Storage=volatile
@@ -31,8 +34,5 @@ RuntimeMaxFileSize={{ journald_max_file_size }}M
 {% endif %}
 {# end of storage specific settings #}
 {# settings below here apply to all storage types #}
-{% if journald_sync_interval | int != 0 %}
-SyncIntervalSec={{ journald_sync_interval }}m
-{% endif %}
 Compress={{ journald_compression | bool | ternary("yes", "no") }}
 ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}

--- a/tests/tests_example.yml
+++ b/tests/tests_example.yml
@@ -7,62 +7,83 @@
     journald_max_disk_size: 2048
     journald_per_user: true
     journald_sync_interval: 1
+    journald_forward_to_syslog: true
 
   tasks:
-    - name: Run the role
-      include_role:
-        name: linux-system-roles.journald
-        public: true
+    - name: Run test
+      block:
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.journald
+            public: true
 
-    # Make sure services are restarted before we verify system state is correct
-    - name: Flush handlers
-      meta: flush_handlers
+        # Make sure services are restarted before we verify system state
+        # is correct
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Get systemd-journald service state
-      command:
-        # noqa command-instead-of-module
-        cmd: systemctl show --property SubState systemd-journald.service
-      register: systemctl
-      changed_when: false
+        - name: Get systemd-journald service state
+          command:
+            # noqa command-instead-of-module
+            cmd: systemctl show --property SubState systemd-journald.service
+          register: systemctl
+          changed_when: false
 
-    - name: Verify that systemd-journald is running
-      assert:
-        that: systemctl.stdout == 'SubState=running'
+        - name: Verify that systemd-journald is running
+          assert:
+            that: systemctl.stdout == 'SubState=running'
 
-    - name: Verify that /var/log/journal/$MACHINE_ID/system.journal exists
-      stat:
-        path: /var/log/journal/{{ ansible_machine_id }}/system.journal
-      register: __stat
-      failed_when: not __stat.stat.exists
+        - name: Verify that syslog is set properly
+          command: >-
+            grep ForwardToSyslog=yes
+            "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+          changed_when: false
 
-    - name: Verify that system.journal is in online state
-      shell:
-        cmd: >
-          set -euo pipefail;
-          journalctl --header
-          --file /var/log/journal/{{ ansible_machine_id }}/system.journal |
-          grep -q 'State: ONLINE'
-      changed_when: false
+        - name: Verify that /var/log/journal/$MACHINE_ID/system.journal exists
+          stat:
+            path: /var/log/journal/{{ ansible_machine_id }}/system.journal
+          register: __stat
+          failed_when: not __stat.stat.exists
 
-    - name: Verify that system.journal is compressed
-      shell:
-        cmd: >
-          set -euo pipefail;
-          journalctl --header
-          --file /var/log/journal/{{ ansible_machine_id }}/system.journal |
-          grep -q COMPRESSED
-      changed_when: false
+        - name: Verify that system.journal is in online state
+          shell:
+            cmd: >
+              set -euo pipefail;
+              journalctl --header
+              --file /var/log/journal/{{ ansible_machine_id }}/system.journal |
+              grep -q 'State: ONLINE'
+          changed_when: false
 
-    - name: Verify that system journal can have maximum size of 2.0G
-      shell:
-        cmd: >
-          set -euo pipefail;
-          journalctl -b -u systemd-journald -p info | grep max | tail -n 1 |
-          grep -q -E 'max( allowed)? 2.0G'
-      changed_when: false
+        - name: Verify that system.journal is compressed
+          shell:
+            cmd: >
+              set -euo pipefail;
+              journalctl --header
+              --file /var/log/journal/{{ ansible_machine_id }}/system.journal |
+              grep -q COMPRESSED
+          changed_when: false
 
-    - name: Check generated files for ansible_managed, fingerprint
-      include_tasks: tasks/check_header.yml
-      vars:
-        __file: "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
-        __fingerprint: "system_role:journald"
+        - name: Verify that system journal can have maximum size of 2.0G
+          shell:
+            cmd: >
+              set -euo pipefail;
+              journalctl -b -u systemd-journald -p info | grep max | tail -n 1 |
+              grep -q -E 'max( allowed)? 2.0G'
+          changed_when: false
+
+        - name: Check generated files for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file: "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+            __fingerprint: "system_role:journald"
+      always:
+        - name: Cleanup
+          file:
+            path: "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+            state: absent
+
+        - name: Restart journald services
+          service:
+            name: "{{ item }}"
+            state: restarted
+          loop: "{{ __journald_services }}"


### PR DESCRIPTION
Compress should apply to all storage modes

SyncInterval should apply only to persistent mode, and warn otherwise

Reformat the journald.conf template to make it easier to see which
settings apply to which modes.

Add test for ForwardToSyslog

Ensure the test cleans up properly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
