### PR TITLE
test: fix check for max journal size

### DIFF
--- a/tests/tests_example.yml
+++ b/tests/tests_example.yml
@@ -81,8 +81,9 @@
           shell:
             cmd: >
               set -euo pipefail;
-              journalctl -b -u systemd-journald -p info | grep max | tail -n 1 |
-              grep -q -E 'max( allowed)? 2.0G'
+              journalctl -b -u systemd-journald -p info |
+              grep -E "((System [Jj]ournal)|(Permanent journal)) .*max" | tail -n 1 |
+              grep -q -E 'max( allowed)? 2([.]0)?G'
           changed_when: false
 
         - name: Check generated files for ansible_managed, fingerprint
@@ -90,6 +91,18 @@
           vars:
             __file: "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
             __fingerprint: "system_role:journald"
+
+      rescue:
+        - name: Debug
+          shell: |
+            set -x
+            exec 1>&2
+            journalctl -ex
+            journalctl -b -u systemd-journald
+            cat "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+          changed_when: false
+          failed_when: true
+
       always:
         - name: Cleanup
           file:


### PR DESCRIPTION
Some systems report the max size as 2G instead of 2.0G:

```
Aug 18 17:54:34 xxxxxx systemd-journald[14084]: System Journal (/var/log/journal/c353583eb4fd4abf81720811415b21e0) is 8M, max 2G, 1.9G free.
```

Also add some debugging for test failures

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
