### PR TITLE
feat: Add support for SystemKeepFree journald.conf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ unless otherwise indicated.
   `journald_rate_limit_interval_sec`.
   See `man 5 journald.conf` for more information.
 
-- `journald_system_keep_free` - integer variable in gigabytes, sets the amount of
-  filesystem space in gigabytes that should be kept free if the system is close to
+- `journald_keep_free` - integer variable in megabytes, sets the amount of
+  filesystem space in megabytes that should be kept free if the system (persistent or volatile) is close to
   filling up.
   See `man 5 journald.conf` for more information
 
@@ -87,7 +87,7 @@ unless otherwise indicated.
     journald_max_disk_size: 2048
     journald_per_user: true
     journald_sync_interval: 1
-    journald_system_keep_free: 10
+    journald_keep_free: 10240
   roles:
     - linux-system-roles.journald
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ unless otherwise indicated.
   `journald_rate_limit_interval_sec`.
   See `man 5 journald.conf` for more information.
 
+- `journald_system_keep_free` - integer variable in gigabytes, sets the amount of
+  filesystem space in gigabytes that should be kept free if the system is close to
+  filling up.
+  See `man 5 journald.conf` for more information
+
 ## Example Playbook
 
 ```yaml
@@ -82,6 +87,7 @@ unless otherwise indicated.
     journald_max_disk_size: 2048
     journald_per_user: true
     journald_sync_interval: 1
+    journald_system_keep_free: 10
   roles:
     - linux-system-roles.journald
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,4 @@ journald_sync_interval: 0
 journald_forward_to_syslog: false
 journald_rate_limit_interval_sec: 30
 journald_rate_limit_burst: 10000
-journald_system_keep_free: 10
+journald_keep_free: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ journald_sync_interval: 0
 journald_forward_to_syslog: false
 journald_rate_limit_interval_sec: 30
 journald_rate_limit_burst: 10000
+journald_system_keep_free: 10

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -19,6 +19,9 @@ SplitMode={{ journald_per_user | bool | ternary("uid", "none") }}
 {%   if journald_sync_interval | int != 0 %}
 SyncIntervalSec={{ journald_sync_interval }}m
 {%   endif %}
+{%   if journald_system_keep_free | int != 0 %}
+SystemKeepFree={{ journald_system_keep_free }}G
+{%   endif %}
 {# Volatile journal #}
 {% else %}
 Storage=volatile
@@ -30,6 +33,9 @@ RuntimeMaxFiles={{ journald_max_files }}
 {%   endif %}
 {%   if journald_max_file_size | int != 0 %}
 RuntimeMaxFileSize={{ journald_max_file_size }}M
+{%   endif %}
+{%   if journald_keep_free | int != 0 %}
+RuntimeKeepFree={{ journald_keep_free }}M
 {%   endif %}
 {% endif %}
 {# end of storage specific settings #}

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -19,8 +19,8 @@ SplitMode={{ journald_per_user | bool | ternary("uid", "none") }}
 {%   if journald_sync_interval | int != 0 %}
 SyncIntervalSec={{ journald_sync_interval }}m
 {%   endif %}
-{%   if journald_system_keep_free | int != 0 %}
-SystemKeepFree={{ journald_system_keep_free }}G
+{%   if journald_keep_free | int != 0 %}
+SystemKeepFree={{ journald_keep_free }}M
 {%   endif %}
 {# Volatile journal #}
 {% else %}

--- a/tests/tests_example.yml
+++ b/tests/tests_example.yml
@@ -10,6 +10,7 @@
     journald_forward_to_syslog: true
     journald_rate_limit_burst: 2000
     journald_rate_limit_interval_sec: 2
+    journald_system_keep_free: 10
     __service_files:
       - systemd-journald.service
       - systemd-journal-flush.service
@@ -85,6 +86,12 @@
         - name: Verify that rate limit burst is set properly
           command: >-
             grep RateLimitBurst=2000
+            "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+          changed_when: false
+        
+        - name: Verify that system keep free is set properly
+          command: >-
+            grep SystemKeepFree=10
             "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
           changed_when: false
 

--- a/tests/tests_example.yml
+++ b/tests/tests_example.yml
@@ -10,7 +10,7 @@
     journald_forward_to_syslog: true
     journald_rate_limit_burst: 2000
     journald_rate_limit_interval_sec: 2
-    journald_system_keep_free: 10
+    journald_keep_free: 10
     __service_files:
       - systemd-journald.service
       - systemd-journal-flush.service


### PR DESCRIPTION
Enhancement:
This change adds support for the SystemKeepFree option.

Reason:
It's a configurable option in `journald.conf` that isn't currently available, but is useful to be able to set.

Result:
Set the `SystemKeepFree=` option as per:
https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html

Issue Tracker Tickets (Jira or BZ if any):
nil

## Summary by Sourcery

Add support for the SystemKeepFree setting in journald.conf via a new `journald_system_keep_free` variable.

New Features:
- Introduce `journald_system_keep_free` to configure the SystemKeepFree option in journald.conf.

Enhancements:
- Update the configuration template to include SystemKeepFree when the variable is set.
- Provide a default 10GB value for `journald_system_keep_free` in defaults.

Documentation:
- Document the new `journald_system_keep_free` option in the README with an example.