### PR TITLE
docs(changelog): version 1.4.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -214,6 +215,10 @@ in seconds, configures the time interval within which only
 the upper limit of messages from a service which are handled within the
 time defined by <code>journald_rate_limit_interval_sec</code>. See
 <code>man 5 journald.conf</code> for more information.</p></li>
+<li><p><code>journald_keep_free</code> - integer variable in megabytes,
+sets the amount of filesystem space in megabytes that should be kept
+free if the system (persistent or volatile) is close to filling up. See
+<code>man 5 journald.conf</code> for more information</p></li>
 </ul>
 <h1 id="example-playbook">Example Playbook</h1>
 <div class="sourceCode" id="cb2"><pre
@@ -223,8 +228,9 @@ class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb2-1"><a href="
 <span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">journald_max_disk_size</span><span class="kw">:</span><span class="at"> </span><span class="dv">2048</span></span>
 <span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">journald_per_user</span><span class="kw">:</span><span class="at"> </span><span class="ch">true</span></span>
 <span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">journald_sync_interval</span><span class="kw">:</span><span class="at"> </span><span class="dv">1</span></span>
-<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">roles</span><span class="kw">:</span></span>
-<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> linux-system-roles.journald</span></span></code></pre></div>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="fu">journald_keep_free</span><span class="kw">:</span><span class="at"> </span><span class="dv">10240</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="fu">roles</span><span class="kw">:</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="at">    </span><span class="kw">-</span><span class="at"> linux-system-roles.journald</span></span></code></pre></div>
 <h1 id="rpm-ostree">rpm-ostree</h1>
 <p>See README-ostree.md</p>
 <h1 id="license">License</h1>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+[1.4.0] - 2025-06-16
+--------------------
+
+### New Features
+
+- feat: Add support for SystemKeepFree journald.conf option (#109)
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#94)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#97)
+- ci: Check spelling with codespell (#98)
+- ci: Add test plan that runs CI tests and customize it for each role (#99)
+- ci: In test plans, prefix all relate variables with SR_ (#100)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#101)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#102)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#103)
+- ci: skip storage scsi, nvme tests in github qemu ci (#104)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#105)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#106)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#107)
+- ci: Add support for bootc end-to-end validation tests (#110)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#111)
+
 [1.3.5] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.4.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Release version 1.4.0: introduce journald_keep_free support, refresh changelog, enhance CI workflows, and update documentation accordingly

New Features:
- Add support for the SystemKeepFree journald.conf option

CI:
- Disable ansible-plugin-scan; bump ansible-lint to v25; add codespell spellcheck; refine CI test plans and variable prefixes; fix ARTIFACTS_URL bug; enhance qemu tests; add Fedora 42 and Python 3.13 support; bump testing-farm action

Documentation:
- Update HTML README with CSS tweaks and document the new journald_keep_free variable with description and example