### PR TITLE
feat: Add MaxRetention configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ unless otherwise indicated.
   filling up.
   See `man 5 journald.conf` for more information
 
+- `journald_max_retention` - integer variable, in minutes,
+  sets how long journal entries can be retained before they are deleted.
+  No implicit value is configured by the role.
+
 ## Example Playbook
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ journald_forward_to_syslog: false
 journald_rate_limit_interval_sec: 30
 journald_rate_limit_burst: 10000
 journald_keep_free: 0
+journald_max_retention: 0

--- a/templates/journald.conf.j2
+++ b/templates/journald.conf.j2
@@ -44,3 +44,6 @@ Compress={{ journald_compression | bool | ternary("yes", "no") }}
 ForwardToSyslog={{ journald_forward_to_syslog | bool | ternary("yes", "no") }}
 RateLimitIntervalSec={{ journald_rate_limit_interval_sec }}s
 RateLimitBurst={{ journald_rate_limit_burst }}
+{% if journald_max_retention | int != 0 %}
+MaxRetentionSec={{ journald_max_retention }}m
+{% endif %}

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_example.yml
+++ b/tests/tests_example.yml
@@ -11,6 +11,7 @@
     journald_rate_limit_burst: 2000
     journald_rate_limit_interval_sec: 2
     journald_keep_free: 10
+    journald_max_retention: 30
     __service_files:
       - systemd-journald.service
       - systemd-journal-flush.service
@@ -88,10 +89,16 @@
             grep RateLimitBurst=2000
             "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
           changed_when: false
-        
+
         - name: Verify that system keep free is set properly
           command: >-
             grep SystemKeepFree=10
+            "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
+          changed_when: false
+
+        - name: Verify that max retention is set properly
+          command: >-
+            grep MaxRetentionSec=30m
             "{{ __journald_dropin_dir }}/{{ __journald_dropin_conf }}"
           changed_when: false
 


### PR DESCRIPTION
Feature: Add variable to configure max retention parameter.

Reason: Usually size-based deletion of the journal is sufficient with
such options as `journald_max_disk_size` and `journald_max_files`, but in
some cases time-based deletion is required in order to comply with data
retention policies.

Result: Users can configure journald MaxRetention.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>