### PR TITLE
docs(changelog): version 1.5.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -219,6 +219,9 @@ time defined by <code>journald_rate_limit_interval_sec</code>. See
 sets the amount of filesystem space in megabytes that should be kept
 free if the system (persistent or volatile) is close to filling up. See
 <code>man 5 journald.conf</code> for more information</p></li>
+<li><p><code>journald_max_retention</code> - integer variable, in
+minutes, sets how long journal entries can be retained before they are
+deleted. No implicit value is configured by the role.</p></li>
 </ul>
 <h1 id="example-playbook">Example Playbook</h1>
 <div class="sourceCode" id="cb2"><pre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.5.0] - 2025-07-09
+--------------------
+
+### New Features
+
+- feat: Add MaxRetention configuration (#113)
+
 [1.4.0] - 2025-06-16
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.5.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.5.0 by adding the new MaxRetention journald retention feature and updating associated documentation

New Features:
- Introduce MaxRetention configuration to control maximum journal entry retention duration

Documentation:
- Document the new journald_max_retention variable in README.html