### PR TITLE
ci: add openSUSE Leap 15.6 to integration test matrix

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -41,6 +41,7 @@ jobs:
           - { image: "fedora-42", env: "container-ansible-core-2.17" }
           - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
           - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+          - { image: "leap-15.6", env: "qemu-ansible-core-2.18" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
@@ -62,6 +63,7 @@ jobs:
           case "$image" in
           centos-*) platform=el; platform_version=el"${image#centos-}" ;;
           fedora-*) platform=fedora; platform_version="${image/-/}" ;;
+          leap-*) platform=leap; platform_version="${image}" ;;
           esac
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,3 +2,4 @@
 ---
 collections:
   - ansible.posix
+  - community.general

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,6 @@ galaxy_info:
     - journald
     - logging
     - rhel
+    - leap
+    - sles
 allow_duplicates: true


### PR DESCRIPTION
Enhancement: add openSUSE Leap 15.6 to integration test matrix

Reason: add leap to integration test

Result: Leap 15.6 test runs in CI

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Enable testing on openSUSE Leap 15.6 by extending the CI workflow, updating platform detection, adding relevant Galaxy tags, and including the community.general collection requirement.

New Features:
- Add openSUSE Leap 15.6 to the QEMU-KVM integration test matrix

Enhancements:
- Add 'leap' and 'sles' tags to Galaxy metadata
- Add community.general to the collection requirements

CI:
- Include a CI job for leap-15.6 and handle 'leap-*' images in the platform mapping