### PR TITLE
fix(defaults): journald_per_user set to true

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ journald_persistent: false
 journald_max_disk_size: 0
 journald_max_files: 0
 journald_max_file_size: 0
-journald_per_user: false
+journald_per_user: true
 journald_compression: true
 journald_sync_interval: 0
 journald_forward_to_syslog: false


### PR DESCRIPTION
Enhancement: journald_per_user set to true in defaults

Reason: it's set like this in upstream as the default as well

Result: will split journals based on uid

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/journald/issues/149

## Summary by Sourcery

Enhancements:
- Align journald_per_user default with upstream to split journals by user.